### PR TITLE
Add dependency on g++ package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class mailcatcher {
   package { 'mailcatcher':
     provider => gem,
     ensure => present,
-    require => Package['g++', 'sqlite3', 'libsqlite3-dev']
+    require => Package['g++', 'make', 'sqlite3', 'libsqlite3-dev']
   }
 
   file { '/etc/init/mailcatcher.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,8 @@
 class mailcatcher {
+  package { 'g++':
+    ensure => present
+  }
+  
   package { 'sqlite3':
     ensure => present
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class mailcatcher {
   package { 'mailcatcher':
     provider => gem,
     ensure => present,
-    require => Package['sqlite3', 'libsqlite3-dev']
+    require => Package['g++', 'sqlite3', 'libsqlite3-dev']
   }
 
   file { '/etc/init/mailcatcher.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,4 @@
 class mailcatcher {
-  package { 'g++':
-    ensure => present
-  }
-  
   package { 'sqlite3':
     ensure => present
   }


### PR DESCRIPTION
Without the `g++` package, the mailcatcher gem cannot be built.
